### PR TITLE
whitelist github.io

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -79,3 +79,4 @@ flowcode.com
 withkoji.com
 dualshockers.com
 discordstatus.com
+github.io


### PR DESCRIPTION
This is currently flagged by Phishing.Database.