### PR TITLE
add dribble to whitelist

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -82,3 +82,4 @@ discordstatus.com
 github.io
 streamable.com
 amazon.com
+dribbble.com


### PR DESCRIPTION
Add dribble.com (https://dribbble.com/) to domain whitelist.