### PR TITLE
Add go-link.ru to followers

### DIFF
--- a/followers.json
+++ b/followers.json
@@ -98,5 +98,10 @@
     "domain": "qptr.ru",
     "include_subdomains": false,
     "type": "HEADER"
+  },
+  {
+    "domain": "go-link.ru",
+    "include_subdomains": false,
+    "type": "META"
   }
 ]


### PR DESCRIPTION
Example scam links (do not click!):
- https://go-link.ru/oLBMB
- https://go-link.ru/P4OMB